### PR TITLE
Update discord invite url

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@ Ledger's the smartest way to secure your crypto assets. Buy, exchange and grow y
 * Website: https://www.ledger.com/
 * Shop: https://shop.ledger.com/
 * Twitter: https://twitter.com/Ledger
-* Discord: https://discord.gg/QrsPHdnr9h
+* Discord: https://discord.gg/ledger
 * Support: https://twitter.com/Ledger_Support
 * Developer Portal: https://developers.ledger.com/
 * Open positions: https://jobs.lever.co/ledger


### PR DESCRIPTION
The old Discord invite URL is no longer valid and Ledger now has a vanity URL