### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -28,9 +28,11 @@ _Those projects are now deprecated and the monorepo is to be used as the source 
 * [ui](https://github.com/LedgerHQ/ui) - Design and interface resources for React and React-Native projects within Ledger
 * [ledgerjs](https://github.com/LedgerHQ/ledgerjs) - Ledger's javascript libraries
 
-### Ledger Live SDK
+### Ledger Wallet API
 
-* [app-sdk](https://github.com/LedgerHQ/live-app-sdk) - Integrate your application or service inside Ledger Live
+Monorepo architecture containing all Ledger Wallet API ecosystem, allowing you to integrate your application in a Ledger wallet (today only Ledger Live wallet is handled)
+
+* [wallet-api](https://github.com/LedgerHQ/wallet-api)
 
 ### Solidity
 


### PR DESCRIPTION
live-app-sdk is now deprecated and replaced by wallet-api. Updating the README to reflect these changes